### PR TITLE
session-test

### DIFF
--- a/src/test/java/com/calorator/mapper/ReportMapperTest.java
+++ b/src/test/java/com/calorator/mapper/ReportMapperTest.java
@@ -1,0 +1,82 @@
+package com.calorator.mapper;
+
+import com.calorator.dto.ReportDTO;
+import com.calorator.entity.ReportEntity;
+import com.calorator.entity.UserEntity;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReportMapperTest {
+
+    @Test
+    void testToEntity_validReportDTOProvided_validUserEntityProvided(){
+
+        ReportDTO reportDTO = new ReportDTO();
+        reportDTO.setId(1L);
+        reportDTO.setReportDate(LocalDate.of(2025, 1, 12));
+        reportDTO.setCreatedAt(LocalDateTime.of(2025, 1, 10, 12, 0));
+        reportDTO.setUpdatedAt(LocalDateTime.of(2025, 1, 11, 14, 0));
+
+        UserEntity user = new UserEntity();
+        user.setId(1L);
+        user.setName("borarrena");
+        user.setEmail("bora.rrena@fti.edu.al");
+
+        ReportEntity report = ReportMapper.toEntity(reportDTO, user);
+
+        assertNotNull(report);
+        assertEquals(reportDTO.getId(), report.getId());
+        assertEquals(reportDTO.getReportDate(), report.getReportDate());
+        assertEquals(reportDTO.getCreatedAt(), report.getCreatedAt());
+        assertEquals(reportDTO.getUpdatedAt(), report.getUpdatedAt());
+        assertEquals(user, report.getAdmin());
+    }
+
+    @Test
+    void testToEntity_validReportDTOProvided_nullUserEntityProvided(){
+        ReportDTO reportDTO = new ReportDTO();
+        assertThrows(NullPointerException.class, ()-> ReportMapper.toEntity(reportDTO, null));
+    }
+
+    @Test
+    void testToEntity_nullReportDTOProvided_nullUserEntityProvided(){
+        UserEntity user = new UserEntity();
+        assertThrows(NullPointerException.class, ()-> ReportMapper.toEntity(null, user));
+    }
+
+    @Test
+    void testToDTO_validReportEntityProvided(){
+        UserEntity user = new UserEntity();
+        user.setId(1L);
+        user.setName("borarrena");
+        user.setEmail("bora.rrena@fti.edu.al");
+        user.setRole(UserEntity.Role.admin);
+
+        ReportEntity report = new ReportEntity();
+        report.setId(1L);
+        report.setAdmin(user);
+        report.setReportDate(LocalDate.of(2025, 1, 12));
+        report.setCreatedAt(LocalDateTime.of(2025, 1, 10, 12, 0));
+        report.setUpdatedAt(LocalDateTime.of(2025, 1, 11, 14, 0));
+
+        ReportDTO reportDTO = ReportMapper.toDTO(report);
+
+        assertNotNull(reportDTO);
+        assertEquals(report.getUpdatedAt(), reportDTO.getUpdatedAt());
+        assertEquals(report.getReportDate(), reportDTO.getReportDate());
+        assertEquals(report.getCreatedAt(), reportDTO.getCreatedAt());
+        assertEquals(report.getUpdatedAt(), reportDTO.getUpdatedAt());
+        assertNotNull(reportDTO.getAdmin());
+        assertEquals(user.getId(), reportDTO.getAdmin().getId());
+
+    }
+
+    @Test
+    void testToDTO_nullReportEntityProvided(){
+        assertThrows(NullPointerException.class, ()-> ReportMapper.toDTO(null));
+    }
+}


### PR DESCRIPTION
Implementimi i MonthlyExpenditureMapperTest ku kam marre parasysh 5 raste:
1) Therras toEntity ku MonthlyExpenditureDTO dhe UserEntity jane te sakta (pra jo null) ku presim qe te mos te mos na kthehet nje vlere null e entitetit foodEntry dhe qe atributet ne DTO dhe Entity te jene te njejta.
2) Therras toEntity ku UserEntity eshte null dhe pres qe te hidhet nje NullPointerException
3) Therras toEntity ku MonthlyExpenditureDTO eshte null dhe pres te hidhet nje NullPointerException
4) Therras toDTO ku MonthlyExpenditureEntity eshte jo null. Presim te na kthehet nje DTO dhe atributet DTO dhe Entity te kene vlera te njejta.
5) Therras toDTO ku MonthlyExpenditureEntity eshte null. Presim te hidhet nje NullPointerException
